### PR TITLE
Display sql with migration name

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -64,7 +64,7 @@ class SqlMigrationError extends MarinerError {
     super(...args);
 
     this.name = 'SqlMigrationError';
-    this.message = 'Migration sql error: "' + sqlError + '" in migration ' + migrationName;
+    this.message = 'Migration ' + migrationName + ' resulted in the following error: ' + sqlError;
   }
 }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -59,6 +59,15 @@ class NoDownMigrationError extends MarinerError {
   }
 }
 
+class SqlMigrationError extends MarinerError {
+  constructor(migrationName, sqlError, ...args) {
+    super(...args);
+
+    this.name = 'SqlMigrationError';
+    this.message = 'Migration sql error: "' + sqlError + '" in migration ' + migrationName;
+  }
+}
+
 export default {
   MarinerError,
   MigrationsDirectoryNotFoundError,
@@ -66,4 +75,5 @@ export default {
   MigrationMissingError,
   InvalidMigrationError,
   NoDownMigrationError,
+  SqlMigrationError,
 };

--- a/src/mariner.js
+++ b/src/mariner.js
@@ -11,6 +11,7 @@ import {
   MigrationMissingError,
   InvalidMigrationError,
   NoDownMigrationError,
+  SqlMigrationError
 } from './errors';
 
 export default {
@@ -22,4 +23,5 @@ export default {
   MigrationMissingError,
   InvalidMigrationError,
   NoDownMigrationError,
+  SqlMigrationError,
 };

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -15,6 +15,7 @@ import {
   MigrationMissingError,
   InvalidMigrationError,
   NoDownMigrationError,
+  SqlMigrationError,
 } from './errors';
 
 const UP = 'up';
@@ -150,6 +151,9 @@ export default class Migrate {
         } else {
           console.log('⛵\tDOWN: %s', name);
         }
+      })
+      .catch((err) => {
+        throw new SqlMigrationError(name, err.message);
       });
   }
 


### PR DESCRIPTION
If an migration sql fails it will display the error message and the corresponding migration file name. Example;

`ERROR:  Migration 20151218110825_test.sql resulted in the following error: relation "bob" does not exist`
